### PR TITLE
Install -e for coverage report

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           apt update && apt install -y python3-pip
           python3 -m pip install --upgrade pip
           pip install pytest-cov codecov coverage
-          pip install .
+          pip install -e .
       - name: Test with pytest
         run: |
           source bin/rob_folders_source.sh


### PR DESCRIPTION
This PR aims at actually getting coverage values out of our coverage build.