### PR TITLE
Use correct package name in installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ install pipx``).
 
 .. code:: bash
 
-   pipx install robot_folders
+   pipx install robot-folders
 
 Upgrade
 ^^^^^^^
@@ -32,7 +32,7 @@ To upgrade robot_folders using ``pipx`` do
 
 .. code:: bash
 
-   pipx upgrade robot_folders
+   pipx upgrade robot-folders
 
 Shell setup
 ^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ install pipx``).
 
 .. code:: bash
 
-   pipx install robot_folders
+   pipx install robot-folders
 
 Upgrade
 -------
@@ -15,7 +15,7 @@ To upgrade robot_folders using ``pipx`` do
 
 .. code:: bash
 
-   pipx upgrade robot_folders
+   pipx upgrade robot-folders
 
 Shell setup
 -----------


### PR DESCRIPTION
While installing "robot_folders" seems to work, the correct package name is "robot-folders"