### PR TITLE
Write currently active env to prompt

### DIFF
--- a/bin/rob_folders_source.sh
+++ b/bin/rob_folders_source.sh
@@ -160,6 +160,7 @@ fzirob()
       if [ $? -eq 0 ]; then
         if [ $1 = "change_environment" ] && [ "$2" != "--help"  ]; then
           checkout_dir=$(rob_folders get_checkout_base_dir)
+
           if [ -f ${checkout_dir}/.cur_env ]; then
             export ROB_FOLDERS_ACTIVE_ENV=$(cat ${checkout_dir}/.cur_env)
             environment_dir="${checkout_dir}/${ROB_FOLDERS_ACTIVE_ENV}"
@@ -175,6 +176,11 @@ fzirob()
             # declare environment-specific aliases
             env_aliases
             #check_env
+            # Write current env to prompt
+            if [ -z "${ROB_FOLDERS_DISABLE_PROMPT_MODIFICATION:-}" ] ; then
+                PS1="[${ROB_FOLDERS_ACTIVE_ENV}] ${PS1:-}"
+                export PS1
+            fi
           else
             echo "Could not change environment"
           fi

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,3 +60,12 @@ Directory options
     Location where build and install steps should be performed if they should be outside of the
     checkout tree. If that folder exists, users will be prompted whether to build inside the
     ``no_backup_dir`` when creating a new environment.
+
+Environment variables
+---------------------
+
+There are also environment variables for some features of ``robot_folders``:
+
+``ROB_FOLDERS_DISABLE_PROMPT_MODIFICATION``
+    If this variable is set to a non-empty value, the currently active environment will **not** be
+    added to the prompt.


### PR DESCRIPTION
This will add the currently active environment to the shell prompt by default. E.g. if your prompt usually looks like this:

```
user@machine:~
```

it will look like this once the environment `foobar` is sourced:

```
[foobar] user@machine:~
```

It is written such that this behavior can be deactivated by setting the environment variable `ROB_FOLDERS_DISABLE_PROMPT_MODIFICATION` to a non-empty value.