### PR TITLE
Do not add the current env multiple times on consecutive sources

### DIFF
--- a/bin/rob_folders_source.sh
+++ b/bin/rob_folders_source.sh
@@ -178,8 +178,11 @@ fzirob()
             #check_env
             # Write current env to prompt
             if [ -z "${ROB_FOLDERS_DISABLE_PROMPT_MODIFICATION:-}" ] ; then
-                PS1="[${ROB_FOLDERS_ACTIVE_ENV}] ${PS1:-}"
-                export PS1
+                env_prompt="[${ROB_FOLDERS_ACTIVE_ENV}]"
+                if [ -n "${PS1##*"$env_prompt"*}" ]; then
+                  PS1="${env_prompt} ${PS1:-}"
+                  export PS1
+                fi
             fi
           else
             echo "Could not change environment"


### PR DESCRIPTION
It is sometimes necessary to re-source the current env (e.g. when new colcon packages were added and built for the first time). Before, the current env would have been added to the prompt once for every source call.

In #18 there was an error introduced...