### PR TITLE
Allow chaining of workspaces

### DIFF
--- a/bin/rob_folders_source.sh
+++ b/bin/rob_folders_source.sh
@@ -166,9 +166,11 @@ fzirob()
             # running change_environment commands in parallel. Thus it can happen that reading the
             # file returns an empty value. This race condition only occurs on a very high io load
             # and usually this while look should only be entered once.
+            ROB_FOLDERS_ACTIVE_ENV=$(cat "${checkout_dir}"/.cur_env) || true
             while [ -z "$ROB_FOLDERS_ACTIVE_ENV" ]; do
-              export ROB_FOLDERS_ACTIVE_ENV=$(cat ${checkout_dir}/.cur_env)
+              ROB_FOLDERS_ACTIVE_ENV=$(cat "${checkout_dir}"/.cur_env) || true
             done
+            export ROB_FOLDERS_ACTIVE_ENV
             environment_dir="${checkout_dir}/${ROB_FOLDERS_ACTIVE_ENV}"
             if [ -f ${environment_dir}/setup.sh ]; then
               source ${environment_dir}/setup.sh

--- a/bin/rob_folders_source.sh
+++ b/bin/rob_folders_source.sh
@@ -49,6 +49,9 @@ if [ -z "$ROB_FOLDERS_ACTIVE_ENV" ]; then
   export ROB_FOLDERS_EMPTY_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
   export ROB_FOLDERS_EMPTY_QML_IMPORT_PATH=${QML_IMPORT_PATH}
   export ROB_FOLDERS_EMPTY_PYTHONPATH=${PYTHONPATH}
+  export ROB_FOLDERS_EMPTY_AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH}
+  export ROB_FOLDERS_EMPTY_COLCON_PREFIX_PATH=${COLCON_PREFIX_PATH}
+  export ROB_FOLDERS_EMPTY_PS1=${PS1}
 
   if [ ! -z "${ROB_FOLDERS_EMPTY_CMAKE_PATH}" ] && [ -z $ROB_FOLDERS_IGNORE_CMAKE_PREFIX_PATH ]
   then
@@ -127,6 +130,8 @@ reset_environment()
   export LD_LIBRARY_PATH=${ROB_FOLDERS_EMPTY_LD_LIBRARY_PATH}
   export QML_IMPORT_PATH=${ROB_FOLDERS_EMPTY_QML_IMPORT_PATH}
   export PYTHONPATH=${ROB_FOLDERS_EMPTY_PYTHONPATH}
+  export AMENT_PREFIX_PATH=${ROB_FOLDERS_EMPTY_AMENT_PREFIX_PATH}
+  export COLCON_PREFIX_PATH=${ROB_FOLDERS_EMPTY_COLCON_PREFIX_PATH}
 }
 
 
@@ -159,6 +164,7 @@ fzirob()
 
       if [ $? -eq 0 ]; then
         if [ $1 = "change_environment" ] && [ "$2" != "--help"  ]; then
+          reset_environment
           checkout_dir=$(rob_folders get_checkout_base_dir)
 
           if [ -f ${checkout_dir}/.cur_env ]; then
@@ -188,7 +194,7 @@ fzirob()
             if [ -z "${ROB_FOLDERS_DISABLE_PROMPT_MODIFICATION:-}" ] ; then
                 env_prompt="[${ROB_FOLDERS_ACTIVE_ENV}]"
                 if [ -n "${PS1##*"$env_prompt"*}" ]; then
-                  PS1="${env_prompt} ${PS1:-}"
+                  PS1="${env_prompt} ${ROB_FOLDERS_EMPTY_PS1:-}"
                   export PS1
                 fi
             fi

--- a/bin/source_environment.sh
+++ b/bin/source_environment.sh
@@ -73,7 +73,7 @@ fi
 
 if [ -z ${rob_folders_overlay+x} ]; then
   echo "Sourcing environment '$environment_dir'"
-  ROB_FOLDERS_ROOT_ENV=$environment_dir
+  export ROB_FOLDERS_ROOT_ENV=$environment_dir
 fi
 
 # This is the environment's name, which we will print out later
@@ -130,6 +130,8 @@ if [ -d $environment_dir ]; then
       export LD_LIBRARY_PATH=${ROB_FOLDERS_EMPTY_LD_LIBRARY_PATH}
       export QML_IMPORT_PATH=${ROB_FOLDERS_EMPTY_QML_IMPORT_PATH}
       export PYTHONPATH=${ROB_FOLDERS_EMPTY_PYTHONPATH}
+      export AMENT_PREFIX_PATH=${ROB_FOLDERS_EMPTY_AMENT_PREFIX_PATH}
+      export COLCON_PREFIX_PATH=${ROB_FOLDERS_EMPTY_COLCON_PREFIX_PATH}
     fi
   fi
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,12 +81,27 @@ To activate or source an environment, use the ``fzirob change_environment
 ENV_NAME`` command. This command sources the appropriate setup scripts of the
 environment depending on its contents.
 
+
 You can use tab completion on the environments so typing ``fzirob
 change_environment`` and then pressing :kbd:`Tab` should list all environments
 present.
 
 Executing ``fzirob change_environment`` without any environment specified will
 source the most recently sourced environment.
+
+
+Adding custom source commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to the environment's workspace setup files, each environment contains a
+``setup_local.sh`` file that will get sourced during the ``change_environment`` call.
+
+.. note::
+
+   Using ``fzirob change_environment`` will reset your shell environment before sourcing a
+   ``robot_folders`` environment. If you want to source your environment based on some altered
+   shell environment (e.g. a sourced python virtualenv), please add the required changes to the
+   ``setup_local.sh`` file in the respective environment.
 
 Using underlay environments
 ---------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -89,19 +89,30 @@ present.
 Executing ``fzirob change_environment`` without any environment specified will
 source the most recently sourced environment.
 
+.. note::
+
+   Using ``fzirob change_environment`` will reset your shell environment before sourcing a
+   ``robot_folders`` environment. Specifically, the following variables will be reset to the state
+   they have been at the point when robot_folders was sourced (the ``rob_folders_source.sh`` file,
+   usually sourced in the ``~/.bashrc`` file).
+
+   * ``CMAKE_PATH``
+   * ``PATH``
+   * ``LD_LIBRARY_PATH``
+   * ``QML_IMPORT_PATH``
+   * ``PYTHONPATH``
+   * ``AMENT_PREFIX_PATH``
+   * ``COLCON_PREFIX_PATH``
+   * ``PS1``
+
 
 Adding custom source commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to the environment's workspace setup files, each environment contains a
-``setup_local.sh`` file that will get sourced during the ``change_environment`` call.
+``setup_local.sh`` file that will get sourced during the ``change_environment`` call after the
+workspaces in an environment have been sourced.
 
-.. note::
-
-   Using ``fzirob change_environment`` will reset your shell environment before sourcing a
-   ``robot_folders`` environment. If you want to source your environment based on some altered
-   shell environment (e.g. a sourced python virtualenv), please add the required changes to the
-   ``setup_local.sh`` file in the respective environment.
 
 Using underlay environments
 ---------------------------


### PR DESCRIPTION
Though it is not recommended to chain workspaces it might be desirable to source a workspace that us not the currently sourced one. With the changes introduced in version 0.5.0 this possibility was removed. This commit re-adds that functionality. The .cur_env file is always read independent of whether the ROB_FOLDERS_ACTIVE_ENV variable is set or not.