### PR TITLE
adds support for colcon args when building colcon workspace

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -34,7 +34,9 @@ Build options
     Set to catkin_make by default but can be changed to catkin build.
 
 ``colcon_build_options``
-    Options passed to each ``colcon build`` invocation that is piped through ``fzirob make``.
+    Options passed to each ``colcon build`` invocation that is piped through ``fzirob make``. These
+    options can be overriden by using the ``--colcon-args`` option when running
+    ``fzirob make colcon``
 
 
 Directory options

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -150,6 +150,10 @@ You can also manually specify which workspace to build by using ``fzirob make
 ros`` or ``fzirob make colcon``. When using ``fzirob make`` you don't have to
 worry about the particular build command at all.
 
+When building a colcon workspace, you can pass arguments to colcon using the ``--colcon-args``
+option. For example to selectivly build a package called ``foobar`` and install it using symlinks
+you can call ``fzirob make --colcon-args --packages-select foobar --symlink-install``.
+
 Default options for building environments such as the builder for catkin
 workspaces or cmake arguments for a colcon workspace can be set in the
 :ref:`configuration:Configuration`.

--- a/src/robot_folders/commands/make.py
+++ b/src/robot_folders/commands/make.py
@@ -42,7 +42,7 @@ class BuildChooser(WorkspaceChooser):
             if name == "ros":
                 return build.CatkinBuilder(name=name, add_help_option=False)
             elif name == "colcon":
-                return build.ColconBuilder(name=name, add_help_option=False)
+                return build.ColconBuilder(name=name, add_help_option=True)
         else:
             click.echo("Did not find a workspace with the key < {} >.".format(name))
             return None

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -155,9 +155,7 @@ class ColconBuilder(Builder):
     """Builder class for colcon workspace"""
 
     def __init__(self, *args, **kwargs):
-        params = [
-            click.Argument(["colcon-args"], nargs=-1, type=click.UNPROCESSED)
-        ]
+        params = [click.Argument(["colcon-args"], nargs=-1, type=click.UNPROCESSED)]
         if "params" in kwargs and kwargs["params"]:
             kwargs["params"].extend(params)
         else:

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -35,7 +35,7 @@ from robot_folders.helpers.which import which
 from robot_folders.helpers import compilation_db_helpers
 from robot_folders.helpers import config_helpers
 from robot_folders.helpers.exceptions import ModuleException
-from robot_folders.helpers.option_helpers import OptionEatAll
+from robot_folders.helpers.option_helpers import SwallowAllOption
 
 
 def get_cmake_flags():
@@ -157,10 +157,9 @@ class ColconBuilder(Builder):
 
     def __init__(self, *args, **kwargs):
         params = [
-            OptionEatAll(
+            SwallowAllOption(
                 ["--colcon-args"],
                 nargs=-1,
-                save_other_options=False,
                 type=click.UNPROCESSED,
             )
         ]

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -161,7 +161,8 @@ class ColconBuilder(Builder):
                 ["--colcon-args"],
                 nargs=-1,
                 help="Arguments passed to colcon. Everything after this flag will be interpreted as"
-                " colcon arguments",
+                " colcon arguments. If this option is set, colcon arguments in the config are "
+                "discarded",
                 type=click.UNPROCESSED,
             )
         ]

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -160,9 +160,12 @@ class ColconBuilder(Builder):
             SwallowAllOption(
                 ["--colcon-args"],
                 nargs=-1,
+                help="Arguments passed to colcon. Everything after this flag will be interpreted as"
+                " colcon arguments",
                 type=click.UNPROCESSED,
             )
         ]
+
         if "params" in kwargs and kwargs["params"]:
             kwargs["params"].extend(params)
         else:

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -154,12 +154,23 @@ class Builder(click.Command):
 class ColconBuilder(Builder):
     """Builder class for colcon workspace"""
 
-    def get_build_command(self, ros_distro):
-        build_cmd = "colcon build"
+    def __init__(self, *args, **kwargs):
+        params = [
+            click.Argument(["colcon-args"], nargs=-1, type=click.UNPROCESSED)
+        ]
+        if "params" in kwargs and kwargs["params"]:
+            kwargs["params"].extend(params)
+        else:
+            kwargs["params"] = params
+        super().__init__(*args, **kwargs)
 
-        colcon_options = config_helpers.get_value_safe_default(
-            section="build", value="colcon_build_options", default=""
-        )
+    def get_build_command(self, ros_distro, colcon_options):
+        if colcon_options is None:
+            colcon_options = config_helpers.get_value_safe_default(
+                section="build", value="colcon_build_options", default=""
+            )
+
+        build_cmd = "colcon build"
 
         generator_flag = ""
         generator = config_helpers.get_value_safe_default(
@@ -193,6 +204,12 @@ class ColconBuilder(Builder):
         colcon_dir = get_colcon_dir()
         click.echo("Building colcon_ws in {}".format(colcon_dir))
 
+        if ctx is not None and "colcon_args" in ctx.params:
+            colcon_args = ctx.params["colcon_args"]
+            colcon_args = " ".join(colcon_args)
+        else:
+            colcon_args = None
+
         # Colcon needs to build in an env that does not have the current workspace sourced
         # See https://docs.ros.org/en/galactic/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay
         my_env = os.environ.copy()
@@ -203,7 +220,7 @@ class ColconBuilder(Builder):
         # We abuse the name to code the ros distribution if we're building for the first time.
         try:
             process = subprocess.check_call(
-                ["bash", "-c", self.get_build_command(self.name)],
+                ["bash", "-c", self.get_build_command(self.name, colcon_args)],
                 cwd=colcon_dir,
                 env=my_env,
             )

--- a/src/robot_folders/helpers/build_helpers.py
+++ b/src/robot_folders/helpers/build_helpers.py
@@ -35,6 +35,7 @@ from robot_folders.helpers.which import which
 from robot_folders.helpers import compilation_db_helpers
 from robot_folders.helpers import config_helpers
 from robot_folders.helpers.exceptions import ModuleException
+from robot_folders.helpers.option_helpers import OptionEatAll
 
 
 def get_cmake_flags():
@@ -155,7 +156,14 @@ class ColconBuilder(Builder):
     """Builder class for colcon workspace"""
 
     def __init__(self, *args, **kwargs):
-        params = [click.Argument(["colcon-args"], nargs=-1, type=click.UNPROCESSED)]
+        params = [
+            OptionEatAll(
+                ["--colcon-args"],
+                nargs=-1,
+                save_other_options=False,
+                type=click.UNPROCESSED,
+            )
+        ]
         if "params" in kwargs and kwargs["params"]:
             kwargs["params"].extend(params)
         else:
@@ -202,7 +210,11 @@ class ColconBuilder(Builder):
         colcon_dir = get_colcon_dir()
         click.echo("Building colcon_ws in {}".format(colcon_dir))
 
-        if ctx is not None and "colcon_args" in ctx.params:
+        if (
+            ctx is not None
+            and "colcon_args" in ctx.params
+            and ctx.params["colcon_args"] is not None
+        ):
             colcon_args = ctx.params["colcon_args"]
             colcon_args = " ".join(colcon_args)
         else:

--- a/src/robot_folders/helpers/option_helpers.py
+++ b/src/robot_folders/helpers/option_helpers.py
@@ -1,0 +1,56 @@
+import click
+
+
+# stolen from https://stackoverflow.com/questions/48391777/nargs-equivalent-for-options-in-click/48394004#48394004
+class OptionEatAll(click.Option):
+    """Option that can have an infite number of arguments"""
+
+    def __init__(self, *args, **kwargs):
+        """
+        - **parameters** and **types**::
+            :param args: Variable length argument list, passed to Option constructor
+            :param kwargs: Variable length keyword argument list, passed to Option constructor
+            :param save_other_options: If set to true, stops parsing if another if another argument
+                                       prefix is encountered (e.g. something starting with a double
+                                       dash like --foo)
+            :type save_other_options: bool
+        """
+        self.save_other_options = kwargs.pop("save_other_options", True)
+        nargs = kwargs.pop("nargs", -1)
+        assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
+        super(OptionEatAll, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            if self.save_other_options:
+                # grab everything up to the next option
+                while state.rargs and not done:
+                    for prefix in self._eat_all_parser.prefixes:
+                        if state.rargs[0].startswith(prefix):
+                            done = True
+                    if not done:
+                        value.append(state.rargs.pop(0))
+            else:
+                # grab everything remaining
+                value += state.rargs
+                state.rargs[:] = []
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+        return retval

--- a/src/robot_folders/helpers/option_helpers.py
+++ b/src/robot_folders/helpers/option_helpers.py
@@ -1,51 +1,26 @@
 import click
 
 
-# stolen from https://stackoverflow.com/questions/48391777/nargs-equivalent-for-options-in-click/48394004#48394004
-class OptionEatAll(click.Option):
-    """Option that can have an infite number of arguments"""
+class SwallowAllOption(click.Option):
+    """Option that swallows all values after it"""
 
     def __init__(self, *args, **kwargs):
-        """
-        - **parameters** and **types**::
-            :param args: Variable length argument list, passed to Option constructor
-            :param kwargs: Variable length keyword argument list, passed to Option constructor
-            :param save_other_options: If set to true, stops parsing if another if another argument
-                                       prefix is encountered (e.g. something starting with a double
-                                       dash like --foo)
-            :type save_other_options: bool
-        """
-        self.save_other_options = kwargs.pop("save_other_options", True)
         nargs = kwargs.pop("nargs", -1)
-        assert nargs == -1, "nargs, if set, must be -1 not {}".format(nargs)
-        super(OptionEatAll, self).__init__(*args, **kwargs)
-        self._previous_parser_process = None
-        self._eat_all_parser = None
+
+        if nargs != -1:
+            raise ValueError("nargs has to be -1")
+
+        super(SwallowAllOption, self).__init__(*args, **kwargs)
 
     def add_to_parser(self, parser, ctx):
-
         def parser_process(value, state):
-            # method to hook to the parser.process
-            done = False
-            value = [value]
-            if self.save_other_options:
-                # grab everything up to the next option
-                while state.rargs and not done:
-                    for prefix in self._eat_all_parser.prefixes:
-                        if state.rargs[0].startswith(prefix):
-                            done = True
-                    if not done:
-                        value.append(state.rargs.pop(0))
-            else:
-                # grab everything remaining
-                value += state.rargs
-                state.rargs[:] = []
+            value = [value] + state.rargs
             value = tuple(value)
+            state.rargs[:] = []
 
-            # call the actual process
             self._previous_parser_process(value, state)
 
-        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
+        retval = super(SwallowAllOption, self).add_to_parser(parser, ctx)
         for name in self.opts:
             our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
             if our_parser:

--- a/tests/test_option_helpers.py
+++ b/tests/test_option_helpers.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2024 FZI Forschungszentrum Informatik
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import click
+
+import pytest
+
+from robot_folders.helpers.option_helpers import SwallowAllOption
+
+
+def test_swallow_all_option():
+    runner = click.testing.CliRunner()
+
+    colcon_args = "--symlink-install --packages-select foobar"
+
+    @click.command()
+    @click.option("--colcon_args", cls=SwallowAllOption)
+    def test_command(colcon_args):
+        click.echo(f"{colcon_args}!")
+
+    result = runner.invoke(test_command, [f"--colcon_args={colcon_args}"])
+    assert result.exit_code == 0
+    assert result.output == f"('{colcon_args}',)!\n"
+
+    with pytest.raises(ValueError):
+
+        @click.command()
+        @click.option("--colcon_args", cls=SwallowAllOption, nargs=2)
+        def illegal_test_command():
+            click.echo("hello")
+
+        runner.invoke(illegal_test_command)


### PR DESCRIPTION
This PR adds support for passing arguments to colcon when using `fzirob make colcon`. For example one can call `fzirob make colcon -- --symlink-install --packages-select abc`. If colcon arguments are passed, the colcon arguments defined in the config are discarded.

clickit only supports unlimited values for arguments or when using the [multiple keyword](https://click.palletsprojects.com/en/8.1.x/options/#multiple-options), requiring the user to pass the `--colcon-args` argument mutiple times. 

You can have unlimited values when using Arguments, but to stop clickit from interpreting something like `--symlink-install` as an argument the `--` is required. It tells clickit to interpret everything after it as arguments (see [here](https://click.palletsprojects.com/en/8.1.x/options/#multiple-options)).