### PR TITLE
Migrate from legacy importlib.path to importlib.files

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.8'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/src/robot_folders/helpers/config_helpers.py
+++ b/src/robot_folders/helpers/config_helpers.py
@@ -27,6 +27,8 @@ import yaml
 
 from importlib import resources
 
+import robot_folders.helpers.resources
+
 XDG_CONFIG_HOME = os.getenv(
     "XDG_CONFIG_HOME", os.path.expandvars(os.path.join("$HOME", ".config"))
 )
@@ -43,8 +45,8 @@ class Userconfig(object):
     @classmethod
     def init_class(cls):
         """Load the distribution config file"""
-        with resources.path(
-            ".".join([__package__, "resources"]), "userconfig_distribute.yaml"
+        with resources.files(robot_folders.helpers.resources).joinpath(
+            "userconfig_distribute.yaml"
         ) as p:
             filename_distribute = p.as_posix()
             file_content = p.read_text()

--- a/src/robot_folders/helpers/config_helpers.py
+++ b/src/robot_folders/helpers/config_helpers.py
@@ -23,6 +23,7 @@
 from __future__ import print_function
 import os
 import shutil
+import sys
 import yaml
 
 from importlib import resources
@@ -35,6 +36,12 @@ XDG_CONFIG_HOME = os.getenv(
 FILENAME_USERCONFIG = os.path.join(XDG_CONFIG_HOME, "robot_folders.yaml")
 
 
+def get_resource_path(filename):
+    if sys.version_info.major == 3 and sys.version_info.minor < 9:
+        return resources.path(".".join([__package__, "resources"]), filename)
+    return resources.files(robot_folders.helpers.resources).joinpath(filename)
+
+
 class Userconfig(object):
     """Class for managing a userconfig"""
 
@@ -45,9 +52,7 @@ class Userconfig(object):
     @classmethod
     def init_class(cls):
         """Load the distribution config file"""
-        with resources.files(robot_folders.helpers.resources).joinpath(
-            "userconfig_distribute.yaml"
-        ) as p:
+        with get_resource_path("userconfig_distribute.yaml") as p:
             filename_distribute = p.as_posix()
             file_content = p.read_text()
             try:


### PR DESCRIPTION
On recent python versions this was raising a deprecation warning. If this also works on the oldest supported version, let's migrate it.