### PR TITLE
Do not die without any installed ROS distro

### DIFF
--- a/bin/source_environment.sh
+++ b/bin/source_environment.sh
@@ -176,17 +176,21 @@ if [ -d $environment_dir ]; then
     else
       echo "no setup.$shell_type for the catkin workspace found. Sourcing global ROS"
       num_ros_distros=$(find /opt/ros -maxdepth 1 -mindepth 1 -type d | wc -l)
-      if [[ $num_ros_distros -gt 1 ]]; then
-        echo "Found more than one ros_distribution:"
-        echo $(ls /opt/ros/)
-        echo "Please insert the distro that should be used:"
-        read ros_distro
+      if [[ $num_ros_distros -eq 0 ]]; then
+        echo "No ROS installation found in /opt/ros. Assuming you take care about your ROS setup otherwise."
       else
-        ros_distro=$(ls /opt/ros/)
+        if [[ $num_ros_distros -gt 1 ]]; then
+          echo "Found more than one ros_distribution:"
+          ls /opt/ros/
+          echo "Please insert the distro that should be used:"
+          read ros_distro
+        else
+          ros_distro=$(ls /opt/ros/)
+        fi
+        setup_file=/opt/ros/$ros_distro/setup.$shell_type
+        source $setup_file
+        echo "sourced $setup_file"
       fi
-      setup_file=/opt/ros/$ros_distro/setup.$shell_type
-      source $setup_file
-      echo "sourced $setup_file"
     fi
   fi
 
@@ -219,17 +223,21 @@ if [ -d $environment_dir ]; then
     else
       echo "no setup.$shell_type for the colcon workspace found. Sourcing global ROS2"
       num_ros_distros=$(find /opt/ros -maxdepth 1 -mindepth 1 -type d | wc -l)
-      if [[ $num_ros_distros -gt 1 ]]; then
-        echo "Found more than one ros_distribution:"
-        echo $(ls /opt/ros/)
-        echo "Please insert the distro that should be used:"
-        read ros_distro
+      if [[ $num_ros_distros -eq 0 ]]; then
+        echo "No ROS installation found in /opt/ros. Assuming you take care about your ROS setup otherwise."
       else
-        ros_distro=$(ls /opt/ros/)
+        if [[ $num_ros_distros -gt 1 ]]; then
+          echo "Found more than one ros_distribution:"
+          ls /opt/ros/
+          echo "Please insert the distro that should be used:"
+          read ros_distro
+        else
+          ros_distro=$(ls /opt/ros/)
+        fi
+        setup_file=/opt/ros/$ros_distro/setup.$shell_type
+        source $setup_file
+        echo "sourced $setup_file"
       fi
-      setup_file=/opt/ros/$ros_distro/setup.$shell_type
-      source $setup_file
-      echo "sourced $setup_file"
     fi
   fi
 

--- a/src/robot_folders/helpers/environment_helpers.py
+++ b/src/robot_folders/helpers/environment_helpers.py
@@ -148,17 +148,21 @@ class CatkinCreator(object):
         version to use and whether to copy the CMakeLists.txt
         """
         if self.ros_distro == "ask":
-            installed_ros_distros = sorted(installed_ros_1_versions())
-            self.ros_distro = installed_ros_distros[-1]
-            if len(installed_ros_distros) > 1:
-                questions = [
-                    inquirer.List(
-                        "ros_distro",
-                        message="Which ROS distribution would you like to use for catkin?",
-                        choices=installed_ros_distros,
-                    ),
-                ]
-                self.ros_distro = inquirer.prompt(questions)["ros_distro"]
+            installed_ros_distros = installed_ros_1_versions()
+            if installed_ros_distros:
+                installed_ros_distros = sorted(installed_ros_distros)
+                self.ros_distro = installed_ros_distros[-1]
+                if len(installed_ros_distros) > 1:
+                    questions = [
+                        inquirer.List(
+                            "ros_distro",
+                            message="Which ROS distribution would you like to use for catkin?",
+                            choices=installed_ros_distros,
+                        ),
+                    ]
+                    self.ros_distro = inquirer.prompt(questions)["ros_distro"]
+            else:
+                self.ros_distro = None
         click.echo("Using ROS distribution '{}'".format(self.ros_distro))
         if self.copy_cmake_lists == "ask":
             self.copy_cmake_lists = click.confirm(
@@ -277,17 +281,21 @@ class ColconCreator(object):
         version to use
         """
         if self.ros2_distro == "ask":
-            installed_ros_distros = sorted(installed_ros_2_versions())
-            self.ros2_distro = installed_ros_distros[-1]
-            if len(installed_ros_distros) > 1:
-                questions = [
-                    inquirer.List(
-                        "ros_distro",
-                        message="Which ROS2 distribution would you like to use for colcon?",
-                        choices=installed_ros_distros,
-                    ),
-                ]
-                self.ros2_distro = inquirer.prompt(questions)["ros_distro"]
+            installed_ros_distros = installed_ros_2_versions()
+            if installed_ros_distros:
+                installed_ros_distros = sorted(installed_ros_distros)
+                self.ros2_distro = installed_ros_distros[-1]
+                if len(installed_ros_distros) > 1:
+                    questions = [
+                        inquirer.List(
+                            "ros_distro",
+                            message="Which ROS2 distribution would you like to use for colcon?",
+                            choices=installed_ros_distros,
+                        ),
+                    ]
+                    self.ros2_distro = inquirer.prompt(questions)["ros_distro"]
+            else:
+                self.ros2_distro = None
         click.echo("Using ROS2 distribution '{}'".format(self.ros2_distro))
 
     def build(self):

--- a/src/robot_folders/helpers/ros_version_helpers.py
+++ b/src/robot_folders/helpers/ros_version_helpers.py
@@ -34,6 +34,8 @@ def installed_ros_distros():
 def installed_ros_1_versions():
     """Returns a list of all installed ROS1 versions"""
     # Check the setup if it contains catkin the ROS Build system
+    if not os.path.exists("/opt/ros"):
+        return None
     temp_installed_ros_distros = os.listdir("/opt/ros")
     installed_ros_distros = []
     for distro in temp_installed_ros_distros:
@@ -45,6 +47,8 @@ def installed_ros_1_versions():
 def installed_ros_2_versions():
     """Returns a list of all installed ROS2 versions"""
     # Check the setup if it contains ament the ROS2 Build system
+    if not os.path.exists("/opt/ros"):
+        return None
     temp_installed_ros_distros = os.listdir("/opt/ros")
     installed_ros_distros = []
     for distro in temp_installed_ros_distros:


### PR DESCRIPTION
People might install ROS by themselves differently, e.g. though a source installation which does not install into /opt/ros or through Robostack.

This commit allows having an empty / non-existing /opt/ros without dying when creating environments (both, catkin and colcon workspaces). The output states that the distro 'None' is used, sourcing without an existing build states that users should take care about sourcing their ROS installation. Building without a source ROS installation will probably lead to errors in the output, but I would leave that to the user's responsibility for now.

E.g. requesting a colcon workspace without an existing ROS installation leads to 
```
Requested to not create a misc workspace
Requested to not create a catkin_ws
Creating colcon_ws
log_dir: /root/checkout/bar2/colcon_ws/log
install_dir: /root/checkout/bar2/colcon_ws/install
Building colcon_ws in /root/checkout/bar2/colcon_ws
Building with command colcon build --symlink-install --cmake-args   -DCMAKE_EXPORT_COMPILE_COMMANDS=1
bash: line 1: colcon: command not found
None
Something went wrong while creating the environment!
Execution of module 'add' failed. Error message:
'None'
```

Closes #38 

@DariusPietschatConbotics if you could test that, that would be really nice!