### PR TITLE
Update python versions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,10 +13,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
+          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,10 +12,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
+          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ robot_folders.egg-info
 src/robot_folders/build/
 build/
 dist/
+.coverage
+coverage.xml


### PR DESCRIPTION
Since Python 3.8 is now EOL and Python 3.13 has been released some time ago, we should update our build matrix.