### PR TITLE
Use importlib instead of deprecated __version__ attribute.

### DIFF
--- a/bin/rob_folders_get_source_command.py
+++ b/bin/rob_folders_get_source_command.py
@@ -23,11 +23,11 @@
 """Small hacky script to get the correct source_zsh command per click version"""
 
 import argparse
-import click
+import importlib.metadata
 
 
 def get_click_version():
-    click_version = click.__version__
+    click_version = importlib.metadata.version("click")
     click_major_version = click_version.split(".")[0]
     return int(click_major_version)
 


### PR DESCRIPTION
This will fix the deprecation warning when sourcing a new shell.

```shell
/home/me/.local/bin/rob_folders_get_source_command.py:30: DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Click 9.1. Use feature detection or 'importlib.metadata.version("click")' instead.
  click_version = click.__version__
```